### PR TITLE
Updated GetEventOptions filters to allow string[]

### DIFF
--- a/lib/docker.d.ts
+++ b/lib/docker.d.ts
@@ -803,16 +803,16 @@ namespace Docker {
         /**
          * A json encoded value of the filters (a `map[string][]string`) to process on the event list.
          * Available filters:
-         *  - `container=<string>`; – container to filter
-         *  - `event=<string>`; – event to filter
-         *  - `image=<string>`; – image to filter
-         *  - `label=<string>`; – image and container label to filter
-         *  - `type=<string>`; – either container or image or volume or network or daemon
-         *  - `volume=<string>`; – volume to filter
-         *  - `network=<string>`; – network to filter
-         *  - `daemon=<string>`; – daemon name or id to filter
+         *  - `container=<string | string[]>`; – container to filter
+         *  - `event=<string | string[]>`; – event to filter
+         *  - `image=<string | string[]>`; – image to filter
+         *  - `label=<string | string[]>`; – image and container label to filter
+         *  - `type=<string | string[]>`; – either container or image or volume or network or daemon
+         *  - `volume=<string | string[]>`; – volume to filter
+         *  - `network=<string | string[]>`; – network to filter
+         *  - `daemon=<string | string[]>`; – daemon name or id to filter
          */
-        filters?: Dictionary<string>;
+        filters?: Dictionary<string | string[]>;
     }
 
     export interface EventResult {


### PR DESCRIPTION
I've tested by updating local type definitions and testing against a Docker daemon. Works as expected.  Contributing the tweak to update main typings.

Thanks!